### PR TITLE
Add ability to filter routes to a certain prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ You can also override the default config provided by the application by running 
 
 Generating the swagger documentation is easy, simply run `php artisan laravel-swagger:generate` in your project root. Keep in mind the command will simply print out the output in your console. If you want the docs saved in a file you can reroute the output like so: `php artisan laravel-swagger:generate > swagger.json`
 
+If you wish to generate docs for a subset of your routes, you can pass a filter using `--filter`, for example: `php artisan laravel-swagger:generate --filter="/api"`
+
 By default, laravel-swagger prints out the documentation in json format, if you want it in YAML format you can override the format using the `--format` flag. Make sure to have the yaml extension installed if you choose to do so.
 
 Format options are:<br>

--- a/src/GenerateSwaggerDoc.php
+++ b/src/GenerateSwaggerDoc.php
@@ -12,7 +12,8 @@ class GenerateSwaggerDoc extends Command
      * @var string
      */
     protected $signature = 'laravel-swagger:generate
-                            {--format=json : The format of the output, current options are json and yaml}';
+                            {--format=json : The format of the output, current options are json and yaml}
+                            {--filter= : Filter to a specific route prefix, such as /api or /v2/api}';
 
     /**
      * The console command description.
@@ -30,7 +31,7 @@ class GenerateSwaggerDoc extends Command
     {
         $config = config('laravel-swagger');
 
-        $docs = (new Generator($config))->generate();
+        $docs = (new Generator($config, $this->option('filter') ?: null))->generate();
 
         $formattedDocs = (new FormatterManager($docs))
             ->setFormat($this->option('format'))

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -11,6 +11,8 @@ class Generator
 {
     protected $config;
 
+    protected $routeFilter;
+
     protected $docs;
 
     protected $uri;
@@ -21,9 +23,10 @@ class Generator
 
     protected $action;
 
-    public function __construct($config)
+    public function __construct($config, $routeFilter = null)
     {
         $this->config = $config;
+        $this->routeFilter = $routeFilter;
     }
 
     public function generate()
@@ -33,6 +36,11 @@ class Generator
         foreach ($this->getAppRoutes() as $route) {
             $this->originalUri = $uri = $this->getRouteUri($route);
             $this->uri = strip_optional_char($uri);
+
+            if ($this->routeFilter && !preg_match('/^' . preg_quote($this->routeFilter, '/') . '/', $this->uri)) {
+                continue;
+            }
+
             $this->action = $route->getAction('uses');
             $methods = $route->methods();
 

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -43,6 +43,8 @@ class GeneratorTest extends TestCase
         $this->assertEquals([
             '/users',
             '/users/{id}',
+            '/api',
+            '/api/store',
         ], array_keys($docs['paths']));
 
         return $docs['paths'];
@@ -104,5 +106,35 @@ class GeneratorTest extends TestCase
         $this->assertContains('https', $docs['schemes']);
         $this->assertContains('application/json', $docs['consumes']);
         $this->assertContains('application/json', $docs['produces']);
+    }
+
+    /**
+     * @param string|null $routeFilter
+     * @param array $expectedRoutes
+     * 
+     * @dataProvider filtersRoutesProvider
+     */
+    public function testFiltersRoutes($routeFilter, $expectedRoutes)
+    {
+        $this->generator = new Generator(
+            $this->config = config('laravel-swagger'),
+            $routeFilter
+        );
+
+        $docs = $this->generator->generate();
+
+        $this->assertEquals($expectedRoutes, array_keys($docs['paths']));
+    }
+
+    /**
+     * @return array
+     */
+    public function filtersRoutesProvider()
+    {
+        return [
+            'No Filter' => [null, ['/users', '/users/{id}', '/api', '/api/store']],
+            '/api Filter' => ['/api', ['/api', '/api/store']],
+            '/=nonexistant Filter' => ['/nonexistant', []],
+        ];
     }
 }

--- a/tests/Stubs/Controllers/ApiController.php
+++ b/tests/Stubs/Controllers/ApiController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Mtrajano\LaravelSwagger\Tests\Stubs\Controllers;
+
+use Illuminate\Routing\Controller;
+
+class ApiController extends Controller
+{
+    public function index()
+    {
+        return json_encode(['result' => 'success']);
+    }
+
+    public function store()
+    {
+        return json_encode(['result' => 'success']);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -16,5 +16,7 @@ class TestCase extends OrchestraTestCase
         $app['router']->get('/users', 'Mtrajano\\LaravelSwagger\\Tests\\Stubs\\Controllers\\UserController@index');
         $app['router']->get('/users/{id}', 'Mtrajano\\LaravelSwagger\\Tests\\Stubs\\Controllers\\UserController@show');
         $app['router']->post('/users', 'Mtrajano\\LaravelSwagger\\Tests\\Stubs\\Controllers\\UserController@store');
+        $app['router']->get('/api', 'Mtrajano\\LaravelSwagger\\Tests\\Stubs\\Controllers\\ApiController@index');
+        $app['router']->put('/api/store', 'Mtrajano\\LaravelSwagger\\Tests\\Stubs\\Controllers\\ApiController@store');
     }
 }


### PR DESCRIPTION
I have a bunch of non-api routes in my app, which I don't need docs generated for. This PR adds a `--filter` option which you can use to filter the generation to a certain prefix.

Let me know if there are any issues or changes you would like.