### PR TITLE
Switch param type default to string

### DIFF
--- a/src/Parameters/PathParameterGenerator.php
+++ b/src/Parameters/PathParameterGenerator.php
@@ -20,7 +20,7 @@ class PathParameterGenerator implements ParameterGenerator
             $params[] = [
                 'in' => $this->getParamLocation(),
                 'name' => strip_optional_char($variable),
-                'type' => 'integer', //best guess for a variable in the path
+                'type' => 'string', //best guess for a variable in the path
                 'required' => $this->isPathVariableRequired($variable),
                 'description' => '',
             ];


### PR DESCRIPTION
Since this is hardcoded, I think it makes more sense to set it to string, as setting to integer breaks tools that load swagger docs and only allow you to enter an int for that field.