### PR TITLE
fix Str::startsWith need string error

### DIFF
--- a/src/Parameters/Concerns/GeneratesFromRules.php
+++ b/src/Parameters/Concerns/GeneratesFromRules.php
@@ -19,11 +19,11 @@ trait GeneratesFromRules
     {
         if (in_array('integer', $paramRules)) {
             return 'integer';
-        } else if (in_array('numeric', $paramRules)) {
+        } elseif (in_array('numeric', $paramRules)) {
             return 'number';
-        } else if (in_array('boolean', $paramRules)) {
+        } elseif (in_array('boolean', $paramRules)) {
             return 'boolean';
-        } else if (in_array('array', $paramRules)) {
+        } elseif (in_array('array', $paramRules)) {
             return 'array';
         } else {
             //date, ip, email, etc..
@@ -62,7 +62,7 @@ trait GeneratesFromRules
     private function getInParameter(array $paramRules)
     {
         foreach ($paramRules as $rule) {
-            if (Str::startsWith($rule, 'in:')) {
+            if (is_string($rule) && Str::startsWith($rule, 'in:')) {
                 return $rule;
             }
         }

--- a/src/Parameters/Concerns/GeneratesFromRules.php
+++ b/src/Parameters/Concerns/GeneratesFromRules.php
@@ -19,11 +19,11 @@ trait GeneratesFromRules
     {
         if (in_array('integer', $paramRules)) {
             return 'integer';
-        } elseif (in_array('numeric', $paramRules)) {
+        } else if (in_array('numeric', $paramRules)) {
             return 'number';
-        } elseif (in_array('boolean', $paramRules)) {
+        } else if (in_array('boolean', $paramRules)) {
             return 'boolean';
-        } elseif (in_array('array', $paramRules)) {
+        } else if (in_array('array', $paramRules)) {
             return 'array';
         } else {
             //date, ip, email, etc..

--- a/src/Parameters/Concerns/GeneratesFromRules.php
+++ b/src/Parameters/Concerns/GeneratesFromRules.php
@@ -62,7 +62,7 @@ trait GeneratesFromRules
     private function getInParameter(array $paramRules)
     {
         foreach ($paramRules as $rule) {
-            if (is_string($rule) && Str::startsWith($rule, 'in:')) {
+            if ((is_string($rule) || method_exists($rule , '__toString')) && Str::startsWith($rule, 'in:')) {
                 return $rule;
             }
         }

--- a/tests/Stubs/Rules/Uppercase.php
+++ b/tests/Stubs/Rules/Uppercase.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Mtrajano\LaravelSwagger\Tests\Stubs\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+
+class Uppercase implements Rule
+{
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        return strtoupper($value) === $value;
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return string
+     */
+    public function message()
+    {
+        return 'The :attribute must be uppercase.';
+    }
+}


### PR DESCRIPTION
Hi there, 
First of all, thanks u to spend a lot of time building this awesome package, it really allay the pain to generate api document. 
But I found some problem here at version `"mtrajano/laravel-swagger": "^0.6.0"`, it cause by the commend `php artisan laravel-swagger:generate > swagger.json`
<img width="1103" alt="螢幕快照 2019-12-04 下午2 32 26" src="https://user-images.githubusercontent.com/34828602/70118490-1372ea80-16a3-11ea-88de-41e5d394173b.png">

`GeneratesFromRules.php`
<img width="690" alt="螢幕快照 2019-12-04 下午2 47 59" src="https://user-images.githubusercontent.com/34828602/70119602-9dbc4e00-16a5-11ea-9599-527cc6e91351.png">
The reason is the $rule variable have pass the object (Laravel Rule Object) getting exception, and I already fix this issue, please check up the code below before merge, thanks.

p.s. My editer auto format the `elseif` to `else if` and  I forgot to ignore the change, i haven't change at that line 