### PR TITLE
Fix exception when using Rule classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
 vendor/
+/.idea/.gitignore
+/.idea/laravel-swagger.iml
+/.idea/misc.xml
+/.idea/modules.xml
+/.idea/php.xml
+/.idea/vcs.xml

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ One thing to note is this library leans on being explicit. It will choose to inc
 
 ## Installation
 
-The package can easily be installed by running `composer require mtrajano/laravel-swagger` in your project's root folder.
+The package can easily be installed by running `composer require ivan770/laravel-swagger` in your project's root folder.
 
 If you are running a version of Laravel < 5.5 also make sure you add `Mtrajano\LaravelSwagger\SwaggerServiceProvider::class` to the `providers` array in `config/app.php`.
 

--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,14 @@
 {
-    "name": "mtrajano/laravel-swagger",
+    "name": "ivan770/laravel-swagger",
     "description": "Auto generates the swagger documentation for a laravel project",
     "license": "MIT",
     "authors": [
         {
             "name": "Mauricio Trajano",
             "email": "mauriciot1993@gmail.com"
+        },
+        {
+            "name": "ivan770"
         }
     ],
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "ivan770/laravel-swagger",
-    "description": "Auto generates the swagger documentation for a laravel project",
+    "description": "Auto generates the swagger documentation for a Laravel project",
     "license": "MIT",
     "authors": [
         {

--- a/config/laravel-swagger.php
+++ b/config/laravel-swagger.php
@@ -73,6 +73,6 @@ return [
     */
 
     'baseResponses' => [
-        200 => 'OK'
+        200 => ['description' => 'OK']
     ],
 ];

--- a/config/laravel-swagger.php
+++ b/config/laravel-swagger.php
@@ -62,4 +62,17 @@ return [
     */
 
     'parseDocBlock' => true,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Ignore methods
+    |--------------------------------------------------------------------------
+    |
+    | Methods in the following array will be ignored in the paths array
+    |
+    */
+
+    'baseResponses' => [
+        200 => 'OK'
+    ],
 ];

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -188,7 +188,7 @@ class Generator
         foreach($rawResponses as $response) {
             $split = explode(' ', $response->getDescription(), 2);
             $statusCode = $split[0];
-            $responses[$statusCode] = $split[1];
+            $responses[$statusCode] = ['description' => $split[1]];
         }
 
         return $responses + $this->config['baseResponses'];

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -126,6 +126,7 @@ class Generator
             ],
         ];
 
+        $this->addTagParameters();
         $this->addActionParameters();
     }
 
@@ -144,6 +145,18 @@ class Generator
         if (!empty($parameters)) {
             $this->docs['paths'][$this->uri][$this->method]['parameters'] = $parameters;
         }
+    }
+
+    protected function getModelName()
+    {
+        $match = [];
+        preg_match('/{(.*)}/', $this->uri, $match);
+        return ucfirst($match[1] ?? 'Generic');
+    }
+
+    protected function addTagParameters()
+    {
+        $this->docs['paths'][$this->uri][$this->method]['tags'] = [$this->getModelName()];
     }
 
     protected function getFormRules()

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -146,7 +146,7 @@ class Generator
     protected function getModelName()
     {
         $match = [];
-        preg_match('/{(.*)}/', $this->uri, $match);
+        preg_match('/{(\w*)}/', $this->uri, $match);
         return ucfirst($match[1] ?? 'Generic');
     }
 

--- a/src/Parameters/Concerns/GeneratesFromRules.php
+++ b/src/Parameters/Concerns/GeneratesFromRules.php
@@ -62,6 +62,10 @@ trait GeneratesFromRules
     private function getInParameter(array $paramRules)
     {
         foreach ($paramRules as $rule) {
+            if(is_object($rule)) {
+                continue;
+            }
+            
             if (Str::startsWith($rule, 'in:')) {
                 return $rule;
             }


### PR DESCRIPTION
Fix `ErrorException  : substr() expects parameter 1 to be string, object given` when using object classes in Form Requests