### PR TITLE
Include date format for date types

### DIFF
--- a/src/Parameters/BodyParameterGenerator.php
+++ b/src/Parameters/BodyParameterGenerator.php
@@ -105,6 +105,10 @@ class BodyParameterGenerator implements ParameterGenerator
             $propObj['enum'] = $enums;
         }
 
+        if ($format = $this->getFormatValue($rules)) {
+            $propObj['format'] = $format;
+        }
+
         if ($type === 'array') {
             $propObj['items'] = [];
         } elseif ($type === 'object') {

--- a/src/Parameters/Concerns/GeneratesFromRules.php
+++ b/src/Parameters/Concerns/GeneratesFromRules.php
@@ -46,6 +46,15 @@ trait GeneratesFromRules
         return current(explode('.', $param));
     }
 
+    protected function getFormatValue(array $paramRules)
+    {
+        if (in_array('date', $paramRules)) {
+            return 'date';
+        }
+
+        return false;
+    }
+
     protected function getEnumValues(array $paramRules)
     {
         $in = $this->getInParameter($paramRules);

--- a/tests/Parameters/BodyParameterGeneratorTest.php
+++ b/tests/Parameters/BodyParameterGeneratorTest.php
@@ -47,6 +47,14 @@ class BodyParameterGeneratorTest extends TestCase
      */
     public function testDataTypes($bodyParameters)
     {
+        //Just testing types here
+        $properties = array_map(function($property) {
+            if (!array_key_exists('type', $property)) {
+                return [];
+            }
+            return ['type' => $property['type']];
+        }, $bodyParameters['schema']['properties']);
+
         $this->assertEquals([
             'id'            => ['type' => 'integer'],
             'email'         => ['type' => 'string'],
@@ -55,7 +63,7 @@ class BodyParameterGeneratorTest extends TestCase
             'picture'       => ['type' => 'string'],
             'is_validated'  => ['type' => 'boolean'],
             'score'         => ['type' => 'number'],
-        ], $bodyParameters['schema']['properties']);
+        ], $properties);
     }
 
     public function testNoRequiredParameters()
@@ -75,6 +83,21 @@ class BodyParameterGeneratorTest extends TestCase
             'account_type' => [
                 'type' => 'integer',
                 'enum' => [1, 2],
+            ],
+        ], $bodyParameters['schema']['properties']);
+    }
+
+
+    public function testDateFormatInBody()
+    {
+        $bodyParameters = $this->getBodyParameters([
+            'account_type' => 'date',
+        ]);
+
+        $this->assertEquals([
+            'account_type' => [
+                'type' => 'string',
+                'format' => 'date',
             ],
         ], $bodyParameters['schema']['properties']);
     }


### PR DESCRIPTION
This PR includes the swagger v2 date format for date-typed body parameters.

See https://swagger.io/specification/v2/ under the header Data Types.
It then goes on to list a number of formats which include `date`. 
```
Primitives have an optional modifier property format.
Swagger uses several known formats to more finely define the data type being used.
```