### PR TITLE
Fix PHP8 deprecation in `Generator::getFormRules`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ php:
   - 7.2
   - 7.3
   - 7.4
+  - 8.0
+  - 8.1
 
 before_install:
   - travis_retry composer self-update

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require-dev": {
-        "php": ">=7.0",
+        "php": ">=8.0",
         "orchestra/testbench": "~4.0",
         "phpunit/phpunit": "^8.0|^9.0",
         "laravel/passport": "^8.0"

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -190,13 +190,9 @@ class Generator
         $parameters = $action_instance->getParameters();
 
         foreach ($parameters as $parameter) {
-            $class = $parameter->getClass();
-
-            if (!$class) {
-                continue;
-            }
-
-            $class_name = $class->getName();
+            $class_name = $name = $parameter->getType() && !$parameter->getType()->isBuiltin()
+                ? new \ReflectionClass($parameter->getType()->getName())
+                : null;
 
             if (is_subclass_of($class_name, FormRequest::class)) {
                 return (new $class_name)->rules();


### PR DESCRIPTION
Fixes mtrajano/laravel-swagger#60 

To anyone already using this repo and needing to use this fix for the time being, you can use the following info in your `composer.json`:

```json
    "repositories": {
        "laravel-swagger-php8": {
            "type": "package",
            "package": {
                "name": "mtrajano/laravel-swagger",
                "version": "0.6.5",
                "source": {
                    "url": "https://github.com/viki53/laravel-swagger.git",
                    "type": "git",
                    "reference": "origin/master"
                }
            }
        }
    },
```

This will override your version with my repo without needing to change your dependencies list, that way you can just remove this config later when this repo is updated with the fix.